### PR TITLE
Modify "notch" argument of boxplotBeeswarm()

### DIFF
--- a/R/boxplotBeeswarm.R
+++ b/R/boxplotBeeswarm.R
@@ -6,7 +6,10 @@
 #' @param .data Either a `data.frame`/`tbl_df` object where each column is
 #'   a numeric vector containing values for each box, or a _named_
 #'   `list` object which can be converted to one.
-#' @param notch Should notches be drawn in the boxplots.
+#' @param notch Logical. Should notches be drawn in the boxplots? If FALSE
+#'   (default), a standard box plot will be drawn. If TRUE, notches will
+#'   be added to the median line of each box plot. See `notch` argument of
+#'   [geom_boxplot()].
 #' @param label Character. A label for the grouping variable, i.e. what
 #'   the columns of the data frame represent.
 #' @param main Character. Main title for the plot.
@@ -20,7 +23,7 @@
 #' @param pt.size Numeric. A size for the points. See [geom_point()].
 #' @param pt.color Character. A _fill_ color for the points. See [geom_point()].
 #' @param pt.shape Numeric or Character. Recognized `pch` shapes for the
-#'   points. Recall that `pch = 21 - 25` only are "fill-able". Other point
+#'   points. Recall that *only* `pch = 21 - 25` are "fill-able". Other point
 #'   characters will _not_ take on the color from `pt.color`.
 #'   See [geom_point()].
 #' @param ... Additional arguments passed to [geom_boxplot()].
@@ -28,20 +31,21 @@
 #' @author Stu Field
 #' @seealso [geom_boxplot()], [geom_jitter()]
 #' @examples
-#' df <- lapply(setNames(LETTERS[1:5], letters[1:5]), \(x) rnorm(10, 10, 3)) |>
+#' df <- lapply(setNames(LETTERS[1:5], letters[1:5]), \(x) rnorm(30, 10, 3)) |>
 #'   data.frame() |>
 #'   dplyr::select(d, dplyr::everything())   # move `d` to the front
-#' df
+#' head(df)
 #'
 #' df |> boxplotBeeswarm(main = "Title")
-#' df |> boxplotBeeswarm(pt.color = "cyan")
+#' df |> boxplotBeeswarm(pt.color = "cyan", notch = TRUE) # add notch
 #' df |> boxplotBeeswarm(cols = "grey")     # all boxes 1 color
-#' df |> boxplotBeeswarm(label = "Disease Level", y.lab = "Y", notch = FALSE)
+#' df |> boxplotBeeswarm(label = "Disease Level", y.lab = "Y")
 #'
-#' # Non-fill-able `pt.shape`
+#' # Some point shapes can't be filled with color.
+#' # Example of a non-fillable `pt.shape` value
 #' df |> boxplotBeeswarm(pt.shape = 13)
 #'
-#' # shapes 21 -> 25 are `fill-capable`
+#' # Shapes 21 - 25 are fillable
 #' df |> boxplotBeeswarm(cols = rep("blue", ncol(df)), pt.size = 5,
 #'                        pt.shape = 23, pt.color = "red")
 #' @importFrom rlang sym !! :=
@@ -51,7 +55,7 @@
 #' @importFrom tidyr gather
 #' @export
 boxplotBeeswarm <- function(.data,
-                            notch = TRUE,
+                            notch = FALSE,
                             label = "Group",
                             main = NULL,
                             y.lab = "value",

--- a/R/boxplotSubarray.R
+++ b/R/boxplotSubarray.R
@@ -1,16 +1,18 @@
-#' Plot Boxplots by Subarray (sample)
+#' Plot Boxplots by Subarray (Sample)
 #'
-#' Plots the distribution of of all analytes stratified
-#' by subarray as a boxplot. In SomaScan (`soma_adat`) data format,
-#' a subarray is typically a row or sample in the data.
+#' Plots the distribution of of all analytes, stratified
+#' by subarray, as a boxplot. In SomaScan (`soma_adat`) data format,
+#' the term "subarray" is analogous to sample, and typically indicates a row
+#' or sample in the data.
 #'
 #' @family boxplots
 #' @param .data A `soma_data` or data frame object created via a call to
 #'   [read_adat()].
-#' @param color.by A column name to color the subarrays by. Typically a meta
-#'   data field in the adat such as `SlideId`.
-#' @param labels Character. A column name of `.data` used to label each box.
-#' @param do.log Logical. Should the data should be log10-transformed?
+#' @param color.by Character. A column name to color the subarrays (samples)
+#'   by. This is typically a sample processing or clinical data field in the
+#'   ADAT such as `SlideId`.
+#' @param labels Character. The column name of `.data` used to label each box.
+#' @param do.log Logical. Should the data be log10-transformed?
 #' @param y.lim Numeric. Length 2. The upper- and lower-quantiles of the
 #'   _total_ data used to determine the y-axis limits of the plot.
 #'   If `NULL`, all points are shown.

--- a/man/boxplotBeeswarm.Rd
+++ b/man/boxplotBeeswarm.Rd
@@ -6,7 +6,7 @@
 \usage{
 boxplotBeeswarm(
   .data,
-  notch = TRUE,
+  notch = FALSE,
   label = "Group",
   main = NULL,
   y.lab = "value",
@@ -23,7 +23,10 @@ boxplotBeeswarm(
 a numeric vector containing values for each box, or a \emph{named}
 \code{list} object which can be converted to one.}
 
-\item{notch}{Should notches be drawn in the boxplots.}
+\item{notch}{Logical. Should notches be drawn in the boxplots? If FALSE
+(default), a standard box plot will be drawn. If TRUE, notches will
+be added to the median line of each box plot. See \code{notch} argument of
+\code{\link[=geom_boxplot]{geom_boxplot()}}.}
 
 \item{label}{Character. A label for the grouping variable, i.e. what
 the columns of the data frame represent.}
@@ -45,7 +48,7 @@ For \code{\link[=plotDoubleHist]{plotDoubleHist()}}, must be \code{length = 2}.}
 \item{pt.color}{Character. A \emph{fill} color for the points. See \code{\link[=geom_point]{geom_point()}}.}
 
 \item{pt.shape}{Numeric or Character. Recognized \code{pch} shapes for the
-points. Recall that \code{pch = 21 - 25} only are "fill-able". Other point
+points. Recall that \emph{only} \code{pch = 21 - 25} are "fill-able". Other point
 characters will \emph{not} take on the color from \code{pt.color}.
 See \code{\link[=geom_point]{geom_point()}}.}
 
@@ -58,20 +61,21 @@ Boxplot with "beeswarm" style points.
 Plot a series of boxplots with "beeswarm"-style points added to the boxes.
 }
 \examples{
-df <- lapply(setNames(LETTERS[1:5], letters[1:5]), \(x) rnorm(10, 10, 3)) |>
+df <- lapply(setNames(LETTERS[1:5], letters[1:5]), \(x) rnorm(30, 10, 3)) |>
   data.frame() |>
   dplyr::select(d, dplyr::everything())   # move `d` to the front
-df
+head(df)
 
 df |> boxplotBeeswarm(main = "Title")
-df |> boxplotBeeswarm(pt.color = "cyan")
+df |> boxplotBeeswarm(pt.color = "cyan", notch = TRUE) # add notch
 df |> boxplotBeeswarm(cols = "grey")     # all boxes 1 color
-df |> boxplotBeeswarm(label = "Disease Level", y.lab = "Y", notch = FALSE)
+df |> boxplotBeeswarm(label = "Disease Level", y.lab = "Y")
 
-# Non-fill-able `pt.shape`
+# Some point shapes can't be filled with color.
+# Example of a non-fillable `pt.shape` value
 df |> boxplotBeeswarm(pt.shape = 13)
 
-# shapes 21 -> 25 are `fill-capable`
+# Shapes 21 - 25 are fillable
 df |> boxplotBeeswarm(cols = rep("blue", ncol(df)), pt.size = 5,
                        pt.shape = 23, pt.color = "red")
 }

--- a/man/boxplotGrouped.Rd
+++ b/man/boxplotGrouped.Rd
@@ -28,7 +28,10 @@ a numeric vector containing values for each box, or a \emph{named}
 names of the grouping variable(s). Variables must be either factor
 or character class vectors.}
 
-\item{notch}{Should notches be drawn in the boxplots.}
+\item{notch}{Logical. Should notches be drawn in the boxplots? If FALSE
+(default), a standard box plot will be drawn. If TRUE, notches will
+be added to the median line of each box plot. See \code{notch} argument of
+\code{\link[=geom_boxplot]{geom_boxplot()}}.}
 
 \item{y.lab}{Character. Optional string for the y-axis. Otherwise
 one is automatically generated (default).}
@@ -42,7 +45,7 @@ one is automatically generated (default).}
 See \code{\link[=ggtitle]{ggtitle()}} for \code{ggplot2} style graphics.}
 
 \item{pt.shape}{Numeric or Character. Recognized \code{pch} shapes for the
-points. Recall that \code{pch = 21 - 25} only are "fill-able". Other point
+points. Recall that \emph{only} \code{pch = 21 - 25} are "fill-able". Other point
 characters will \emph{not} take on the color from \code{pt.color}.
 See \code{\link[=geom_point]{geom_point()}}.}
 

--- a/man/boxplotSubarray.Rd
+++ b/man/boxplotSubarray.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/boxplotSubarray.R
 \name{boxplotSubarray}
 \alias{boxplotSubarray}
-\title{Plot Boxplots by Subarray (sample)}
+\title{Plot Boxplots by Subarray (Sample)}
 \usage{
 boxplotSubarray(
   .data,
@@ -17,24 +17,26 @@ boxplotSubarray(
 \item{.data}{A \code{soma_data} or data frame object created via a call to
 \code{\link[=read_adat]{read_adat()}}.}
 
-\item{color.by}{A column name to color the subarrays by. Typically a meta
-data field in the adat such as \code{SlideId}.}
+\item{color.by}{Character. A column name to color the subarrays (samples)
+by. This is typically a sample processing or clinical data field in the
+ADAT such as \code{SlideId}.}
 
-\item{labels}{Character. A column name of \code{.data} used to label each box.}
+\item{labels}{Character. The column name of \code{.data} used to label each box.}
 
 \item{y.lim}{Numeric. Length 2. The upper- and lower-quantiles of the
 \emph{total} data used to determine the y-axis limits of the plot.
 If \code{NULL}, all points are shown.}
 
-\item{do.log}{Logical. Should the data should be log10-transformed?}
+\item{do.log}{Logical. Should the data be log10-transformed?}
 
 \item{apts}{Optional. A subset of analytes (as \code{AptNames}) to add as points
 on top of the subarray boxplot.}
 }
 \description{
-Plots the distribution of of all analytes stratified
-by subarray as a boxplot. In SomaScan (\code{soma_adat}) data format,
-a subarray is typically a row or sample in the data.
+Plots the distribution of of all analytes, stratified
+by subarray, as a boxplot. In SomaScan (\code{soma_adat}) data format,
+the term "subarray" is analogous to sample, and typically indicates a row
+or sample in the data.
 }
 \examples{
 data <- SomaDataIO::example_data


### PR DESCRIPTION
- changed default of `boxplotBeeswarm(notch=` to be FALSE, to match other boxplot functions
- boxplotGrouped() imports arguments from boxplotBeeswarm(), including `notch=`, but `boxplotGrouped(notch=FALSE)`
- updated argument description to describe expected class (logical)
- added detail describing when a boxplot notch is best used

------

I know changing the default of a plotting function could lead to some unexpected behavior downstream (in this case, changing the default of `boxplotBeeswarm(notch=`), but this package is "new" enough that hopefully we can sneak in a change like this early. `boxplotGrouped()` inherits parameter descriptions from `boxplotBeeswarm()`, but the default for `boxplotGrouped(notch=` is FALSE, while the argument description said it was TRUE (since this is the case for `boxplotBeeswarm()`, where the description was inherited from). So there was a mismatch in the docs that could be confusing for users. If we're going to inherit parameters between these functions, I think it makes sense for them to have the same defaults. 

For this PR, I changed the default in `boxplotBeeswarm()` and then updated the examples to add an example where `notch=TRUE`, since the examples no longer have notches by default. This required playing with the example dataset a little bit (I increased the N) so that the notches wouldn't go outside the hinges and produce an error.