### PR TITLE
Fix links to themes vignette for pkgdown website

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -257,8 +257,9 @@ p1 + p2
 ```
 
 More detailed examples illustrating how to apply these themes can be found in 
-the `vignette("SomaPlotr", )`. For a full list of available color scales and 
-themes, see `?SomaPlotr::theme_soma`.
+`vignette("themes-and-palettes")`. 
+For a full list of available color scales and themes, see 
+`?SomaPlotr::theme_soma`.
 
 
 ------------

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ p2 <- p1 +
 <img src="man/figures/README-theme-comparison-1.png" style="display: block; margin: auto auto auto 0;" />
 
 More detailed examples illustrating how to apply these themes can be
-found in the `vignette("SomaPlotr", )`. For a full list of available
+found in `vignette("themes-and-palettes")`. For a full list of available
 color scales and themes, see `?SomaPlotr::theme_soma`.
 
 ------------------------------------------------------------------------

--- a/vignettes/SomaPlotr.Rmd
+++ b/vignettes/SomaPlotr.Rmd
@@ -372,6 +372,6 @@ of the collected sample.
 ## Color Palettes
 
 For examples of all plotting themes and palettes available in this
-package, see the themes vignette (`TODO`).
+package, see the themes vignette (`vignette("themes-and-palettes")`).
 
 


### PR DESCRIPTION
- updated package vignette ("Get Started" page in pkgdown) to remove "TO-DO" and replace with link to themes vignette
- fixed link to themes vignette from README
- fixes #21, fixes #22


## Overview of Pull Request

General description of the purpose for this pull request ...

Fixes #<issue_number>

### Main changes

- bullet 1
- bullet 2

### Change type

Please check the relevant box(es):

- [ ] New feature (no API change; @amanda-hi, @stufield)
- [ ] Bug fix (no API change -> fixes an issue; @amanda-hi, @stufield)
- [ ] Breaking change (fix or feature with API change; @amanda-hi, @stufield)
- [ ] Documentation update (@SLbmangum, @kmurugesan14)
- [ ] Package maintenance (structural, non-code, non-breaking changes; @stufield)
- [ ] README change (@SLbmangum, @kmurugesan14, @nmcnabbSL)
- [ ] LICENSE changes (@SLbmangum)

### Choose reviewer(s)

- [ ] @amanda-hi
- [ ] @stufield
- [ ] @SLbmangum
- [ ] @kmurugesan14
- [ ] @nmcnabbSL

### Reviewer by Department

| Department     | Reviewer      | Change Type          |
|:-------------- |:------------- | -------------------- |
| Bioinformatics | @amanda-hi    | Code, bugs, features |
|                | @stufield     | bugs, features       |
| Legal          | @SLbmangum    | LICENSE              | 
| Product        | @kmurugesan14 | Documentation        |
| Regulatory     | @nmcnabbSL    | Documentation        |

------------

### Code

If appropriate, please add any relevant code ...

```r
head(mtcars)
```
