### PR TITLE
Add Github Action write permission in pkgdown.yaml

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -20,6 +20,9 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
+    permissions:
+      contents: write
+
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
- updated permissions of the 'deploy-pkgdown' GitHub Actions workflow
- job now has write permissions, should resolve pkgdown workflow failures